### PR TITLE
Fix extensions name conflicting with Dart

### DIFF
--- a/lib/src/functions/get.dart
+++ b/lib/src/functions/get.dart
@@ -2,7 +2,7 @@ import '../type/err.dart';
 import '../type/ok.dart';
 import '../type/result.dart';
 
-extension Get<T, E> on Result<T, E> {
+extension GetResult<T, E> on Result<T, E> {
   T? get() {
     var result = this;
     return result is Ok<T> ? result.value : null;

--- a/lib/src/functions/map.dart
+++ b/lib/src/functions/map.dart
@@ -2,7 +2,7 @@ import '../type/err.dart';
 import '../type/ok.dart';
 import '../type/result.dart';
 
-extension Map<T, E> on Result<T, E> {
+extension MapResult<T, E> on Result<T, E> {
   /// Map a [Result]<T, E> to a [Result]<U, E>
   Result<U, E> map<U>(U Function(T value) transform) {
     var result = this;

--- a/lib/src/functions/on.dart
+++ b/lib/src/functions/on.dart
@@ -2,7 +2,7 @@ import '../type/err.dart';
 import '../type/ok.dart';
 import '../type/result.dart';
 
-extension On<T, E> on Result<T, E> {
+extension OnResult<T, E> on Result<T, E> {
   Result<T, E> onSuccess(void Function(T value) block) {
     var result = this;
     if (result is Ok<T>) {

--- a/test/functions/map_test.dart
+++ b/test/functions/map_test.dart
@@ -49,4 +49,9 @@ void main() {
       expect((result as Err).error, 0);
     });
   });
+
+  test('Map extension name should not conflict with Dart Map', () {
+    Result<Map<String, String>, Never> result = const Ok(0).map((value) => {});
+    expect(result.runtimeType, Ok<Map<String, String>>);
+  });
 }


### PR DESCRIPTION
The name of the extension that provides `map` methods was conflicting when trying to create a Map

Closes #1