### PR TITLE
Adding `when` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A `Result<T, E>` class can be either a success (`Ok<T>` class) or an error (`Err
 This package aims to provide convenience methods for:
 - Getting a value [(`get`, `getOr`, `getOrThrow`, `getError`, `getErrorOr` and `getErrorOrThrow`)][get]
 - Mapping a Result value into another Result [(`map`, `mapError` and `mapBoth`)][map]
-- Execute a block based on the result [(`onSuccess` and `onFailure`)][on]
+- Execute a block based on the result [(`onSuccess` and `onFailure`)][on], [(`when`)][when]
 - Wrap a block, transforming it's exception into error [(`runCatching`)][run-catching]
 - Wrap any value to a result based on the nullability [(`toResultOr`)][to-result]
 
@@ -45,5 +45,6 @@ The motivation for creating this package comes from using this library in Kotlin
 [get]: https://github.com/lucastsantos/typed_result/blob/master/lib/src/functions/get.dart
 [map]: https://github.com/lucastsantos/typed_result/blob/master/lib/src/functions/map.dart
 [on]: https://github.com/lucastsantos/typed_result/blob/master/lib/src/functions/on.dart
+[when]: https://github.com/lucastsantos/typed_result/blob/master/lib/src/functions/when.dart
 [run-catching]: https://github.com/lucastsantos/typed_result/blob/master/lib/src/functions/run_catching.dart
 [to-result]: https://github.com/lucastsantos/typed_result/blob/master/lib/src/functions/to_result.dart

--- a/example/main.dart
+++ b/example/main.dart
@@ -62,10 +62,14 @@ void main() {
 
   "\n`map`".log();
   getDate(false).map((_) => "Mapping success").log();
-  getDate(true).map((_) => "Nothing happens; still an instance of DateException").log();
+  getDate(true)
+      .map((_) => "Nothing happens; still an instance of DateException")
+      .log();
 
   "\n`mapError`".log();
-  getDate(false).mapError((_) => "Nothing happens; still an instance of DateTime").log();
+  getDate(false)
+      .mapError((_) => "Nothing happens; still an instance of DateTime")
+      .log();
   getDate(true).mapError((_) => "Mapping error").log();
 
   "\n`mapBoth`".log();
@@ -89,6 +93,16 @@ void main() {
   getDate(true)
       .onSuccess((_) => "Nothing happens".log())
       .onFailure((_) => "On Failure".log());
+
+  "\n`when`".log();
+  getDate(false).when(
+    success: (_) => "When [success]".log(),
+    failure: (_) => "Nothing happens".log(),
+  );
+  getDate(true).when(
+    success: (_) => "Nothing happens".log(),
+    failure: (_) => "When [failure]".log(),
+  );
 
   "\n`runCatching`".log();
   runCatching(() => DateTime.now()).log();

--- a/lib/src/functions/get.dart
+++ b/lib/src/functions/get.dart
@@ -15,7 +15,9 @@ extension GetResult<T, E> on Result<T, E> {
 
   T getOrThrow() {
     var result = this;
-    return result is Ok<T> ? result.value : throw Exception("Tried to obtain value from a failure");
+    return result is Ok<T>
+        ? result.value
+        : throw Exception("Tried to obtain value from a failure");
   }
 
   E? getError() {
@@ -30,6 +32,8 @@ extension GetResult<T, E> on Result<T, E> {
 
   E getErrorOrThrow() {
     var result = this;
-    return result is Err<E> ? result.error : throw Exception("Tried to obtain error value from a success");
+    return result is Err<E>
+        ? result.error
+        : throw Exception("Tried to obtain error value from a success");
   }
 }

--- a/lib/src/functions/map.dart
+++ b/lib/src/functions/map.dart
@@ -3,7 +3,7 @@ import '../type/ok.dart';
 import '../type/result.dart';
 
 extension MapResult<T, E> on Result<T, E> {
-  /// Map a [Result]<T, E> to a [Result]<U, E>
+  /// Map a [Result]<T, E> to a [Result]<U, E>.
   Result<U, E> map<U>(U Function(T value) transform) {
     var result = this;
     if (result is Ok<T>) {
@@ -13,7 +13,7 @@ extension MapResult<T, E> on Result<T, E> {
     }
   }
 
-  /// Map a [Result]<T, E> to a [Result]<T, F>
+  /// Map a [Result]<T, E> to a [Result]<T, F>.
   Result<T, F> mapError<F>(F Function(E error) transform) {
     var result = this;
     if (result is Err<E>) {
@@ -23,8 +23,10 @@ extension MapResult<T, E> on Result<T, E> {
     }
   }
 
-  /// Map a [Result]<T, E> to a [Result]<U, F>
-  Result<U, F> mapBoth<U, F>({required U Function(T value) success, required F Function(E error) failure}) {
+  /// Map a [Result]<T, E> to a [Result]<U, F>.
+  Result<U, F> mapBoth<U, F>(
+      {required U Function(T value) success,
+      required F Function(E error) failure}) {
     var result = this;
     if (result is Ok<T>) {
       return Ok<U>(success(result.value));

--- a/lib/src/functions/on.dart
+++ b/lib/src/functions/on.dart
@@ -3,6 +3,7 @@ import '../type/ok.dart';
 import '../type/result.dart';
 
 extension OnResult<T, E> on Result<T, E> {
+  /// Invokes [block] only if this is a success.
   Result<T, E> onSuccess(void Function(T value) block) {
     var result = this;
     if (result is Ok<T>) {
@@ -11,6 +12,7 @@ extension OnResult<T, E> on Result<T, E> {
     return this;
   }
 
+  /// Invokes [block] only if this is a failure.
   Result<T, E> onFailure(void Function(E error) block) {
     var result = this;
     if (result is Err<E>) {

--- a/lib/src/functions/when.dart
+++ b/lib/src/functions/when.dart
@@ -1,0 +1,19 @@
+import '../type/err.dart';
+import '../type/ok.dart';
+import '../type/result.dart';
+
+extension WhenResult<T, E> on Result<T, E> {
+  /// Invokes [success] or [failure] block
+  /// depending if this result is a success or a failure.
+  Result<T, E> when(
+      {required void Function(T value) success,
+      required void Function(E error) failure}) {
+    var result = this;
+    if (result is Ok<T>) {
+      success(result.value);
+    } else {
+      failure((result as Err<E>).error);
+    }
+    return this;
+  }
+}

--- a/lib/typed_result.dart
+++ b/lib/typed_result.dart
@@ -5,6 +5,7 @@ export 'src/functions/map.dart';
 export 'src/functions/on.dart';
 export 'src/functions/run_catching.dart';
 export 'src/functions/to_result.dart';
+export 'src/functions/when.dart';
 export 'src/type/err.dart';
 export 'src/type/ok.dart';
 export 'src/type/result.dart';

--- a/test/functions/when_test.dart
+++ b/test/functions/when_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:typed_result/typed_result.dart';
+
+void main() {
+  group('when', () {
+    test('should invoke only the success block when it is success', () {
+      int success = 0;
+      int failure = 0;
+      const Ok("").when(
+        success: (_) {
+          success += 1;
+        },
+        failure: (_) {
+          failure += 1;
+        },
+      );
+      expect(success, 1);
+      expect(failure, 0);
+    });
+
+    test('should invoke only the failure block when it is failure', () {
+      int success = 0;
+      int failure = 0;
+      const Err("").when(
+        success: (_) {
+          success += 1;
+        },
+        failure: (_) {
+          failure += 1;
+        },
+      );
+      expect(success, 0);
+      expect(failure, 1);
+    });
+  });
+}

--- a/test/type/err_test.dart
+++ b/test/type/err_test.dart
@@ -20,7 +20,9 @@ void main() {
     test('two Err results with same values should generate same hashcode', () {
       expect(const Err(0).hashCode == const Err(0).hashCode, true);
     });
-    test('two Err results with different values should not generate same hashcode', () {
+    test(
+        'two Err results with different values should not generate same hashcode',
+        () {
       expect(const Err(0).hashCode == const Err(1).hashCode, false);
     });
   });

--- a/test/type/ok_test.dart
+++ b/test/type/ok_test.dart
@@ -20,7 +20,9 @@ void main() {
     test('two Ok results with same values should generate same hashcode', () {
       expect(const Ok(0).hashCode == const Ok(0).hashCode, true);
     });
-    test('two Ok results with different values should not generate same hashcode', () {
+    test(
+        'two Ok results with different values should not generate same hashcode',
+        () {
       expect(const Ok(0).hashCode == const Ok(1).hashCode, false);
     });
   });


### PR DESCRIPTION
An alternative to `onSuccess` and `onFailure`, for cases when you want to specify both.

### onSuccess + onFailure
```dart
  result.onSuccess((value) { 
    print(value);
  });
  result.onFailure((error) {
    print(error);
  });
```

### when
```dart
  result.when(
    success: (value) {
      print(value);
    },
    failure: (error) {
      print(error);
    },
  );
```