### PR TITLE
Raised minimum Dart; Adding partition method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
+## 2.0.0
+
+- Breaking change: Raised minimum Dart to >=3.0.0
+- Added `partition` function.
+
 ## 1.0.2
 
 - Added extensions for handling with Futures
+- Raised maximum Dart constraint to <4.0.0
 
 ## 1.0.1
 

--- a/example/main.dart
+++ b/example/main.dart
@@ -93,12 +93,8 @@ void map() {
 /// Sample for showing how to invoke block based on the Result outcome.
 void on() {
   print("\n`on`");
-  ok
-      .onSuccess((_) => print("onSuccess"))
-      .onFailure(noop);
-  err
-      .onSuccess(noop)
-      .onFailure((_) => print("onFailure"));
+  ok.onSuccess((_) => print("onSuccess")).onFailure(noop);
+  err.onSuccess(noop).onFailure((_) => print("onFailure"));
 }
 
 /// Sample for showing an alternative on how to invoke block based on the Result outcome.

--- a/lib/src/functions/partition.dart
+++ b/lib/src/functions/partition.dart
@@ -1,0 +1,26 @@
+import '../type/err.dart';
+import '../type/ok.dart';
+import '../type/result.dart';
+
+extension PartitionResult<T, E> on Iterable<Result<T, E>> {
+  /// Partitions a collection of Results into two separate lists based on their types.
+  ///
+  /// This function iterates over the input collection of Results and categorizes them into two lists:
+  /// one for successful results (Ok) containing values of type [V],
+  /// and another for error results (Err) containing errors of type [E].
+  /// It returns a Pair of these two lists.
+  (List<T>, List<E>) partition() {
+    List<T> values = [];
+    List<E> errors = [];
+
+    forEach((result) {
+      if (result is Ok<T>) {
+        values.add(result.value);
+      } else if (result is Err<E>) {
+        errors.add(result.error);
+      }
+    });
+
+    return (values, errors);
+  }
+}

--- a/lib/typed_result.dart
+++ b/lib/typed_result.dart
@@ -4,6 +4,7 @@ export 'src/functions/and.dart';
 export 'src/functions/get.dart';
 export 'src/functions/map.dart';
 export 'src/functions/on.dart';
+export 'src/functions/partition.dart';
 export 'src/functions/run_catching.dart';
 export 'src/functions/to_result.dart';
 export 'src/functions/when.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: typed_result
 description: A result monad with two subtypes representing a success or a failure
 repository: https://github.com/lucastsantos/typed_result
-version: 1.0.2
+version: 2.0.0
 
 environment:
-  sdk: '>=2.18.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   matcher: ^0.12.13

--- a/test/functions/partition_test.dart
+++ b/test/functions/partition_test.dart
@@ -1,0 +1,27 @@
+import 'package:test/test.dart';
+import 'package:typed_result/typed_result.dart';
+
+void main() {
+  group('partition', () {
+    test('should return only values if there is no failure', () {
+      List<Result<int, int>> results = [const Ok(1), const Ok(2)];
+      final (values, errors) = results.partition();
+      expect(values, [1, 2]);
+      expect(errors, isEmpty);
+    });
+
+    test('should return only failures if there is no success', () {
+      List<Result<int, int>> results = [const Err(1), const Err(2)];
+      final (values, errors) = results.partition();
+      expect(values, isEmpty);
+      expect(errors, [1, 2]);
+    });
+
+    test('should correctly return with a mix of success and failure', () {
+      List<Result<int, int>> results = [const Ok(1), const Err(2)];
+      final (values, errors) = results.partition();
+      expect(values, [1]);
+      expect(errors, [2]);
+    });
+  });
+}


### PR DESCRIPTION
Implemented `partition` method for Iterable<Result<V, E>> to categorize results into two lists.
Given a list of Result, it will split into two lists of values and errors.

This PR also bumps to a minimum of Dart 3. 